### PR TITLE
QCamera2: Provide camera output colorspace to video.

### DIFF
--- a/QCamera2/HAL/QCameraMem.cpp
+++ b/QCamera2/HAL/QCameraMem.cpp
@@ -1255,7 +1255,8 @@ QCameraVideoMemory::QCameraVideoMemory(camera_request_memory memory,
     memset(mMetadata, 0, sizeof(mMetadata));
     mMetaBufCount = 0;
     mBufType = bufType;
-    mUsage = 0;
+    //Set Default color conversion format
+    mUsage = private_handle_t::PRIV_FLAGS_ITU_R_601_FR;
 }
 
 /*===========================================================================
@@ -1293,7 +1294,7 @@ int QCameraVideoMemory::allocate(uint8_t count, size_t size, uint32_t isSecure)
         return rc;
     }
 
-    int usage = mUsage | private_handle_t::PRIV_FLAGS_ITU_R_709;
+    int usage = mUsage | private_handle_t::PRIV_FLAGS_ITU_R_601_FR;
 
     if (mBufType != CAM_STREAM_BUF_TYPE_USERPTR) {
         rc = allocateMeta(count);
@@ -1349,7 +1350,7 @@ int QCameraVideoMemory::allocateMore(uint8_t count, size_t size)
         return rc;
     }
 
-    int usage = mUsage | private_handle_t::PRIV_FLAGS_ITU_R_709;
+    int usage = mUsage | private_handle_t::PRIV_FLAGS_ITU_R_601_FR;
 
     if (mBufType != CAM_STREAM_BUF_TYPE_USERPTR) {
         for (int i = mBufferCount; i < count + mBufferCount; i ++) {


### PR DESCRIPTION
Set the camera output colorspace in native handle
instead of indicating video encoder output colorspace.
709 was configured to video to get 709 colorspace output from
video. But now video to decide final configuration and camera
to configure input format which is 601.
CRs-Fixed: 997590
Change-Id: Iedf04bc2968ded10c3e536ec6b23dfe246fa4d00